### PR TITLE
Correctly handle the case where initscr fails to set stdscr to the newly created window

### DIFF
--- a/g_src/renderer_curses.cpp
+++ b/g_src/renderer_curses.cpp
@@ -305,7 +305,13 @@ extern "C" {
     // Initialize curses
     if (!curses_initialized) {
       curses_initialized = true;
-      initscr();
+      WINDOW *new_window = initscr();
+      if (!new_window) {
+        puts("unable to create ncurses window - initscr failed!");
+        exit(EXIT_FAILURE);
+      }
+      // in some versions of curses, initscr does not update stdscr!
+      if (!*stdscr_p) *stdscr_p = new_window;
       raw();
       noecho();
       keypad(*stdscr_p, true);


### PR DESCRIPTION
Correctly handle the case where initscr fails to set stdscr to the newly created window, by setting it manually. Makes curses mode work on my machine.
